### PR TITLE
Fix: Add networks to nginx container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -137,6 +137,8 @@ services:
       - user-service
       - matching-service
       - collaboration-service
+    networks:
+      - app-network
 
   # ChatService
   chat-service:


### PR DESCRIPTION
I dealt with a merge conflict wrongly in the previous PR.
Added `networks: app-network` to nginx container in docker-compose.yaml
